### PR TITLE
Cache connection so checklist and observation data end up in same db

### DIFF
--- a/R/ebird_conn.R
+++ b/R/ebird_conn.R
@@ -9,7 +9,9 @@
 #' which will return [tbl] objects ready for access using [dplyr] syntax.
 #' 
 #' @param dataset the type of dataset to set up a connection to, either the 
-#'   observations of checklists.
+#' observations of checklists.
+#' @param cache_connection should we preserve a cache of the connection? allows
+#'   faster load times and prevents connection from being garbage-collected.
 #' @param memory_limit the memory limit for DuckDB.
 #' 
 #' @return A [DBI] connection object using to communicate with the DuckDB 
@@ -29,25 +31,48 @@
 #' 
 #' unlink(temp_dir, recursive = TRUE)
 ebird_conn <- function(dataset = c("observations", "checklists"), 
+                       cache_connection = TRUE,
                        memory_limit = 4) {
   dataset <- match.arg(dataset)
+  stopifnot(is.logical(cache_connection), length(cache_connection) == 1)
   stopifnot(is.numeric(memory_limit), length(memory_limit) == 1,
             !is.na(memory_limit), memory_limit > 0)
   parquet <- ebird_parquet_files(dataset = dataset)
   
-  ## Is it worth persisting the duckdb connection on disk to avoid
-  ## recreating the View? (~ 9m operation)
+  # query to create view in duckdb to the parquet file
+  view_query <- paste0("CREATE VIEW '", dataset, 
+                       "' AS SELECT * FROM parquet_scan('",
+                       parquet, "');")
+  
+  # check for a cached connection
+  conn <- mget("birddb", envir = birddb_cache, ifnotfound = NA)[["birddb"]]
+  if (inherits(conn, "DBIConnection") ) {
+    if (DBI::dbIsValid(conn)) {
+      # if view not already in databse, create it
+      if (!dataset %in% DBI::dbListTables(conn)) {
+        DBI::dbSendQuery(conn, view_query)
+      }
+      return(conn)
+    } else {
+      # shut down invalid cached connection to allow re-connection
+      DBI::dbDisconnect(conn, shutdown = TRUE)
+    }
+  }
+  
+  # TODO: consider persisting connection on disk to avoid recreating view
   conn <- DBI::dbConnect(drv = duckdb::duckdb(), ebird_db_dir())
   
+  # set memory limit
+  # TODO: temp approach for testing, improve approach in production
   DBI::dbExecute(conn = conn, 
                  paste0("PRAGMA memory_limit='", memory_limit, "GB'"))
   
-  # create a "View" in duckdb to the parquet file
-  if (!dataset %in% DBI::dbListTables(conn)) {
-    query <- paste0("CREATE VIEW '", dataset,
-                    "' AS SELECT * FROM parquet_scan('",
-                    parquet, "');")
-    DBI::dbSendQuery(conn, query)
+  # create view to parquet file
+  DBI::dbSendQuery(conn, view_query)
+  
+  # cache the connection
+  if (cache_connection) {
+    assign("birddb", conn, envir = birddb_cache)
   }
   return(conn)
 }
@@ -71,13 +96,20 @@ ebird_parquet_files <- function(dataset = c("observations", "checklists")) {
   return(file)
 }
 
-# ebird_conn_arrow <- function() {
-#   con <- DBI::dbConnect(duckdb::duckdb())
-#   dir <- file.path(ebird_data_dir(), "parquet")
-# 
-#   # ds <- arrow_open_ebird_txt("/minio/shared-data/ebd_relJul-2021.txt.gz", dir)
-#   ds <- arrow::open_dataset(dir)
-#   ## OOM & crashes
-#   duckdb::duckdb_register_arrow(con, "ebd", ds)
-#   con
-# }
+# environment to store the cached copy of the connection
+birddb_cache <- new.env()
+
+# finalizer to close the connection on exit.
+local_db_disconnect <- function(db = ebird_conn()){
+  if (inherits(db, "DBIConnection")) {
+    suppressWarnings({
+      DBI::dbDisconnect(db, shutdown = TRUE)
+    })
+  }
+  if (exists("birddb", envir = birddb_cache)) {
+    suppressWarnings({
+      rm("birddb", envir = birddb_cache)
+    })
+  }
+}
+reg.finalizer(birddb_cache, local_db_disconnect, onexit = TRUE)

--- a/R/ebird_conn.R
+++ b/R/ebird_conn.R
@@ -46,7 +46,7 @@ ebird_conn <- function(dataset = c("observations", "checklists"),
   
   # check for a cached connection
   conn <- mget("birddb", envir = birddb_cache, ifnotfound = NA)[["birddb"]]
-  if (inherits(conn, "DBIConnection") ) {
+  if (inherits(conn, "DBIConnection")) {
     if (DBI::dbIsValid(conn)) {
       # if view not already in databse, create it
       if (!dataset %in% DBI::dbListTables(conn)) {

--- a/man/ebird_conn.Rd
+++ b/man/ebird_conn.Rd
@@ -4,11 +4,18 @@
 \alias{ebird_conn}
 \title{Set up a \code{DBI}-style database connection to the imported eBird data}
 \usage{
-ebird_conn(dataset = c("observations", "checklists"), memory_limit = 4)
+ebird_conn(
+  dataset = c("observations", "checklists"),
+  cache_connection = TRUE,
+  memory_limit = 4
+)
 }
 \arguments{
 \item{dataset}{the type of dataset to set up a connection to, either the
 observations of checklists.}
+
+\item{cache_connection}{should we preserve a cache of the connection? allows
+faster load times and prevents connection from being garbage-collected.}
 
 \item{memory_limit}{the memory limit for DuckDB.}
 }

--- a/tests/testthat/test-ebird.R
+++ b/tests/testthat/test-ebird.R
@@ -1,7 +1,6 @@
 test_that("birddb works", {
   temp_dir <- file.path(tempdir(), "birddb")
-  Sys.setenv("BIRDDB_HOME" = temp_dir) 
-  Sys.setenv("BIRDDB_DUCKDB" = temp_dir) 
+  Sys.setenv("BIRDDB_HOME" = temp_dir)
   
   import_ebird(sample_observation_data())
   import_ebird(sample_checklist_data())
@@ -16,8 +15,6 @@ test_that("birddb works", {
   expect_s3_class(out, "data.frame")
   expect_gt(nrow(out), 0)
   
-  DBI::dbDisconnect(con, shutdown = TRUE)
-  
   # checklists 
   con <- ebird_conn("checklists")
   checklists <- checklists(con)
@@ -27,8 +24,6 @@ test_that("birddb works", {
   out <- checklists %>% dplyr::count(country) %>% dplyr::collect()
   expect_s3_class(out, "data.frame")
   expect_gt(nrow(out), 0)
-  
-  DBI::dbDisconnect(con, shutdown = TRUE)
   
   unlink(temp_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-ebird.R
+++ b/tests/testthat/test-ebird.R
@@ -1,14 +1,14 @@
 test_that("birddb works", {
   temp_dir <- file.path(tempdir(), "birddb")
-  Sys.setenv("BIRDDB_HOME" = tempdir()) 
+  Sys.setenv("BIRDDB_HOME" = temp_dir) 
   Sys.setenv("BIRDDB_DUCKDB" = temp_dir) 
   
   import_ebird(sample_observation_data())
   import_ebird(sample_checklist_data())
   
-  
   # observations
-  observations <- observations()
+  con <- ebird_conn("observations")
+  observations <- observations(con)
   expect_s3_class(observations, "tbl")
   expect_s3_class(observations, "tbl_dbi")
   
@@ -16,9 +16,11 @@ test_that("birddb works", {
   expect_s3_class(out, "data.frame")
   expect_gt(nrow(out), 0)
   
+  DBI::dbDisconnect(con, shutdown = TRUE)
   
-  # checklists
-  checklists <- checklists()
+  # checklists 
+  con <- ebird_conn("checklists")
+  checklists <- checklists(con)
   expect_s3_class(checklists, "tbl")
   expect_s3_class(checklists, "tbl_dbi")
   
@@ -26,5 +28,7 @@ test_that("birddb works", {
   expect_s3_class(out, "data.frame")
   expect_gt(nrow(out), 0)
   
-  unlink(temp_dir)
+  DBI::dbDisconnect(con, shutdown = TRUE)
+  
+  unlink(temp_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-ebird.R
+++ b/tests/testthat/test-ebird.R
@@ -10,6 +10,7 @@ test_that("birddb works", {
   observations <- observations(con)
   expect_s3_class(observations, "tbl")
   expect_s3_class(observations, "tbl_dbi")
+  expect_equal(DBI::dbListTables(con), "observations")
   
   out <- observations %>% dplyr::count(common_name) %>% dplyr::collect()
   expect_s3_class(out, "data.frame")
@@ -20,10 +21,15 @@ test_that("birddb works", {
   checklists <- checklists(con)
   expect_s3_class(checklists, "tbl")
   expect_s3_class(checklists, "tbl_dbi")
+  # ensure that both tables are in the same database
+  expect_equal(sort(DBI::dbListTables(con)), 
+               c("checklists", "observations"))
   
   out <- checklists %>% dplyr::count(country) %>% dplyr::collect()
   expect_s3_class(out, "data.frame")
   expect_gt(nrow(out), 0)
   
+  # cleanup
+  DBI::dbDisconnect(con, shutdown = TRUE)
   unlink(temp_dir, recursive = TRUE)
 })


### PR DESCRIPTION
I managed to borrow a Windows machine to look into that check error. It seems on Windows you can't create both the checklist and observation views in the same folder on disk, so I've just modified the test to store the views in memory. I also found explicitly disconnecting from the first database with `DBI::dbDisconnect(con, shutdown = TRUE)` before connecting to the second also works.

Obviously this isn't an ideal long term solution, more of a stop gap measure. Not sure what the right approach is here though, e.g. always store views in memory, create a new subdir of `BIRDDB_DUCKDB` for each new connection?