### PR TITLE
Patches for current nightly arrow + duckdb

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,6 +68,7 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
           install.packages("https://github.com/duckdb/duckdb/releases/download/master-builds/duckdb_r_src.tar.gz", repos = NULL)
+          install.packages("arrow", repos = "https://arrow-r-nightly.s3.amazonaws.com")
 
         shell: Rscript {0}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,5 @@ URL: https://github.com/cboettig/birddb
 BugReports: https://github.com/cboettig/birddb
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3

--- a/R/ebird_conn.R
+++ b/R/ebird_conn.R
@@ -32,7 +32,7 @@
 #' unlink(temp_dir, recursive = TRUE)
 ebird_conn <- function(dataset = c("observations", "checklists"), 
                        cache_connection = TRUE,
-                       memory_limit = 4) {
+                       memory_limit = 16) {
   
   dataset <- match.arg(dataset)
   

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,18 +73,21 @@ import_ebird(tar)
 Once the data have been downloaded and imported successfully, a user can access the full ebird record quite quickly:
 
 ```{r}  
-df <- ebird()
-df
+chklists <- checklists()
+obs <- observations()
+
 ```
 
 Now, we can use `dplyr` to perform standard queries:
 
 ```{r}
-colnames(df)
+colnames(obs)
 ```
 
 ```{r}
-df %>% count(scientific_name, sort=TRUE)
+sp <- obs %>% count(`SCIENTIFIC NAME`, sort=TRUE)
+
+bench::bench_time({collect(sp)})
 ```
 
 

--- a/man/ebird_conn.Rd
+++ b/man/ebird_conn.Rd
@@ -7,7 +7,7 @@
 ebird_conn(
   dataset = c("observations", "checklists"),
   cache_connection = TRUE,
-  memory_limit = 4
+  memory_limit = 16
 )
 }
 \arguments{


### PR DESCRIPTION
Import fails on current nightlies of arrow + duckdb with column type parsing errors from the .txt.gz file.  Merely allowing type inference seems to work better than declaring the schema as before.

Some additional work needed here for name repair, in particular, in dropping the empty column (due to the spurious extra tab char at line endings in the example txt.gz).